### PR TITLE
use switch instead of nested ifs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,10 @@
 module github.com/ef-ds/deque
+
+go 1.11
+
+require (
+	github.com/christianrpetrin/queue-tests v0.0.0-20181113195552-8536b5b8f660
+	github.com/gammazero/deque v0.0.0-20180920172122-f6adf94963e4
+	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d
+	gopkg.in/karalabe/cookiejar.v2 v2.0.0-20150724131613-8dcd6a7f4951
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/christianrpetrin/queue-tests v0.0.0-20181113195552-8536b5b8f660 h1:T4BnFIqh6Seu950iWM5xBBO243119XTcg61Fvs9vHUo=
+github.com/christianrpetrin/queue-tests v0.0.0-20181113195552-8536b5b8f660/go.mod h1:ugRPbaHYSO8Ewen14D8j/131oaTGup0SlHocDQ3oIOM=
+github.com/gammazero/deque v0.0.0-20180920172122-f6adf94963e4 h1:R+19WKQClnfMXS60cP5BmMe1wjZ4u0evY2p2Ar0ZTXo=
+github.com/gammazero/deque v0.0.0-20180920172122-f6adf94963e4/go.mod h1:GeIq9qoE43YdGnDXURnmKTnGg15pQz4mYkXSTChbneI=
+github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d h1:U+PMnTlV2tu7RuMK5etusZG3Cf+rpow5hqQByeCzJ2g=
+github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d/go.mod h1:lXfE4PvvTW5xOjO6Mba8zDPyw8M93B6AQ7frTGnMlA8=
+gopkg.in/karalabe/cookiejar.v2 v2.0.0-20150724131613-8dcd6a7f4951 h1:DMTcQRFbEH62YPRWwOI647s2e5mHda3oBPMHfrLs2bw=
+gopkg.in/karalabe/cookiejar.v2 v2.0.0-20150724131613-8dcd6a7f4951/go.mod h1:owOxCRGGeAx1uugABik6K9oeNu1cgxP/R9ItzLDxNWA=


### PR DESCRIPTION
This indents the code less. There is no performance penalty.

Also remove the LastPosition constants, as these are directly
related to the SliceSize constants, and it's easier to understand
if those are used instead IMHO.

Also make the go.mod file reflect the actual dependencies and check in the go.sum file.