### PR TITLE
remove New and Init

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -83,31 +83,8 @@ func TestWithZeroValueAndEmptyShouldReturnAsEmpty(t *testing.T) {
 	}
 }
 
-func TestInitShouldReturnEmptyDeque(t *testing.T) {
-	var d deque.Deque
-	d.PushBack(1)
-
-	d.Init()
-
-	if _, ok := d.Front(); ok {
-		t.Error("Expected: false as the queue is empty; Got: true")
-	}
-	if _, ok := d.Back(); ok {
-		t.Error("Expected: false as the queue is empty; Got: true")
-	}
-	if _, ok := d.PopFront(); ok {
-		t.Error("Expected: false as the queue is empty; Got: true")
-	}
-	if _, ok := d.PopBack(); ok {
-		t.Error("Expected: false as the queue is empty; Got: true")
-	}
-	if l := d.Len(); l != 0 {
-		t.Errorf("Expected: 0 as the queue is empty; Got: %d", l)
-	}
-}
-
 func TestPopFrontWithNilValuesShouldReturnAllValuesInOrder(t *testing.T) {
-	d := deque.New()
+	d := new(deque.Deque)
 	d.PushBack(1)
 	d.PushBack(nil)
 	d.PushBack(2)
@@ -136,7 +113,7 @@ func TestPopFrontWithNilValuesShouldReturnAllValuesInOrder(t *testing.T) {
 }
 
 func TestPopBackWithNilValuesShouldReturnAllValuesInOrder(t *testing.T) {
-	d := deque.New()
+	d := new(deque.Deque)
 	d.PushBack(1)
 	d.PushBack(nil)
 	d.PushBack(2)

--- a/benchmark-direct_test.go
+++ b/benchmark-direct_test.go
@@ -33,7 +33,7 @@ package deque_test
 // 	for _, test := range tests {
 // 		b.Run(strconv.Itoa(test.count), func(b *testing.B) {
 // 			for n := 0; n < b.N; n++ {
-// 				q := deque.New()
+// 				q := new(deque.Deque)
 // 				for i := 0; i < test.count; i++ {
 // 					q.PushBack(getTestValue(i))
 // 				}
@@ -49,7 +49,7 @@ package deque_test
 // 	for _, test := range tests {
 // 		b.Run(strconv.Itoa(test.count), func(b *testing.B) {
 // 			for n := 0; n < b.N; n++ {
-// 				q := deque.New()
+// 				q := new(deque.Deque)
 // 				for i := 0; i < test.count; i++ {
 // 					q.PushBack(getTestValue(i))
 // 				}
@@ -70,7 +70,7 @@ package deque_test
 // 		}
 
 // 		b.Run(strconv.Itoa(test.count), func(b *testing.B) {
-// 			q := deque.New()
+// 			q := new(deque.Deque)
 // 			for n := 0; n < b.N; n++ {
 // 				for n := 0; n < refillCount; n++ {
 // 					for i := 0; i < test.count; i++ {
@@ -88,7 +88,7 @@ package deque_test
 // func BenchmarkRefillDequeStackDirect(b *testing.B) {
 // 	for _, test := range tests {
 // 		b.Run(strconv.Itoa(test.count), func(b *testing.B) {
-// 			q := deque.New()
+// 			q := new(deque.Deque)
 // 			for n := 0; n < b.N; n++ {
 // 				for n := 0; n < refillCount; n++ {
 // 					for i := 0; i < test.count; i++ {
@@ -104,7 +104,7 @@ package deque_test
 // }
 
 // func BenchmarkRefillFullDequeQueueDirect(b *testing.B) {
-// 	d := deque.New()
+// 	d := new(deque.Deque)
 // 	for i := 0; i < fillCount; i++ {
 // 		d.PushBack(getTestValue(i))
 // 	}
@@ -136,7 +136,7 @@ package deque_test
 // }
 
 // func BenchmarkRefillFullDequeStackDirect(b *testing.B) {
-// 	d := deque.New()
+// 	d := new(deque.Deque)
 // 	for i := 0; i < fillCount; i++ {
 // 		d.PushBack(getTestValue(i))
 // 	}
@@ -162,7 +162,7 @@ package deque_test
 // }
 
 // func BenchmarkStableDequeQueueDirect(b *testing.B) {
-// 	d := deque.New()
+// 	d := new(deque.Deque)
 // 	for i := 0; i < fillCount; i++ {
 // 		d.PushBack(getTestValue(i))
 // 	}
@@ -184,7 +184,7 @@ package deque_test
 // }
 
 // func BenchmarkStableDequeStackDirect(b *testing.B) {
-// 	d := deque.New()
+// 	d := new(deque.Deque)
 // 	for i := 0; i < fillCount; i++ {
 // 		d.PushBack(getTestValue(i))
 // 	}
@@ -209,7 +209,7 @@ package deque_test
 // 	for _, test := range tests {
 // 		b.Run(strconv.Itoa(test.count), func(b *testing.B) {
 // 			for n := 0; n < b.N; n++ {
-// 				d := deque.New()
+// 				d := new(deque.Deque)
 // 				for i := 0; i < test.count; i++ {
 // 					d.PushBack(getTestValue(i))
 // 					d.PushBack(getTestValue(i))
@@ -227,7 +227,7 @@ package deque_test
 // 	for _, test := range tests {
 // 		b.Run(strconv.Itoa(test.count), func(b *testing.B) {
 // 			for n := 0; n < b.N; n++ {
-// 				d := deque.New()
+// 				d := new(deque.Deque)
 // 				for i := 0; i < test.count; i++ {
 // 					d.PushBack(getTestValue(i))
 // 					d.PushBack(getTestValue(i))
@@ -242,7 +242,7 @@ package deque_test
 // }
 
 // func BenchmarkSlowDecreaseDequeQueueDirect(b *testing.B) {
-// 	d := deque.New()
+// 	d := new(deque.Deque)
 // 	for _, test := range tests {
 // 		items := test.count / 2
 // 		for i := 0; i <= items; i++ {
@@ -270,7 +270,7 @@ package deque_test
 // }
 
 // func BenchmarkSlowDecreaseDequeStackDirect(b *testing.B) {
-// 	d := deque.New()
+// 	d := new(deque.Deque)
 // 	for _, test := range tests {
 // 		items := test.count / 2
 // 		for i := 0; i <= items; i++ {

--- a/benchmark-fill_test.go
+++ b/benchmark-fill_test.go
@@ -246,7 +246,7 @@ func BenchmarkFillDequeQueue(b *testing.B) {
 	benchmarkFill(
 		b,
 		func() {
-			q = deque.New()
+			q = new(deque.Deque)
 		},
 		func(v interface{}) {
 			q.PushBack(v)
@@ -265,7 +265,7 @@ func BenchmarkFillDequeStack(b *testing.B) {
 	benchmarkFill(
 		b,
 		func() {
-			q = deque.New()
+			q = new(deque.Deque)
 		},
 		func(v interface{}) {
 			q.PushBack(v)

--- a/benchmark-microservice_test.go
+++ b/benchmark-microservice_test.go
@@ -246,7 +246,7 @@ func BenchmarkMicroserviceDequeQueue(b *testing.B) {
 	benchmarkMicroservice(
 		b,
 		func() {
-			q = deque.New()
+			q = new(deque.Deque)
 		},
 		func(v interface{}) {
 			q.PushBack(v)
@@ -265,7 +265,7 @@ func BenchmarkMicroserviceDequeStack(b *testing.B) {
 	benchmarkMicroservice(
 		b,
 		func() {
-			q = deque.New()
+			q = new(deque.Deque)
 		},
 		func(v interface{}) {
 			q.PushBack(v)

--- a/benchmark-refill-full_test.go
+++ b/benchmark-refill-full_test.go
@@ -246,7 +246,7 @@ func BenchmarkRefillFullDequeQueue(b *testing.B) {
 	benchmarkRefillFull(
 		b,
 		func() {
-			q = deque.New()
+			q = new(deque.Deque)
 		},
 		func(v interface{}) {
 			q.PushBack(v)
@@ -265,7 +265,7 @@ func BenchmarkRefillFullDequeStack(b *testing.B) {
 	benchmarkRefillFull(
 		b,
 		func() {
-			q = deque.New()
+			q = new(deque.Deque)
 		},
 		func(v interface{}) {
 			q.PushBack(v)

--- a/benchmark-refill_test.go
+++ b/benchmark-refill_test.go
@@ -246,7 +246,7 @@ func BenchmarkRefillDequeQueue(b *testing.B) {
 	benchmarkRefill(
 		b,
 		func() {
-			q = deque.New()
+			q = new(deque.Deque)
 		},
 		func(v interface{}) {
 			q.PushBack(v)
@@ -265,7 +265,7 @@ func BenchmarkRefillDequeStack(b *testing.B) {
 	benchmarkRefill(
 		b,
 		func() {
-			q = deque.New()
+			q = new(deque.Deque)
 		},
 		func(v interface{}) {
 			q.PushBack(v)

--- a/benchmark-slow-decrease_test.go
+++ b/benchmark-slow-decrease_test.go
@@ -246,7 +246,7 @@ func BenchmarkSlowDecreaseDequeQueue(b *testing.B) {
 	benchmarkSlowDecrease(
 		b,
 		func() {
-			q = deque.New()
+			q = new(deque.Deque)
 		},
 		func(v interface{}) {
 			q.PushBack(v)
@@ -265,7 +265,7 @@ func BenchmarkSlowDecreaseDequeStack(b *testing.B) {
 	benchmarkSlowDecrease(
 		b,
 		func() {
-			q = deque.New()
+			q = new(deque.Deque)
 		},
 		func(v interface{}) {
 			q.PushBack(v)

--- a/benchmark-slow-increase_test.go
+++ b/benchmark-slow-increase_test.go
@@ -246,7 +246,7 @@ func BenchmarkSlowIncreaseDequeQueue(b *testing.B) {
 	benchmarkSlowIncrease(
 		b,
 		func() {
-			q = deque.New()
+			q = new(deque.Deque)
 		},
 		func(v interface{}) {
 			q.PushBack(v)
@@ -265,7 +265,7 @@ func BenchmarkSlowIncreaseDequeStack(b *testing.B) {
 	benchmarkSlowIncrease(
 		b,
 		func() {
-			q = deque.New()
+			q = new(deque.Deque)
 		},
 		func(v interface{}) {
 			q.PushBack(v)

--- a/benchmark-stable_test.go
+++ b/benchmark-stable_test.go
@@ -246,7 +246,7 @@ func BenchmarkStableDequeQueue(b *testing.B) {
 	benchmarkStable(
 		b,
 		func() {
-			q = deque.New()
+			q = new(deque.Deque)
 		},
 		func(v interface{}) {
 			q.PushBack(v)
@@ -265,7 +265,7 @@ func BenchmarkStableDequeStack(b *testing.B) {
 	benchmarkStable(
 		b,
 		func() {
-			q = deque.New()
+			q = new(deque.Deque)
 		},
 		func(v interface{}) {
 			q.PushBack(v)

--- a/deque.go
+++ b/deque.go
@@ -98,17 +98,6 @@ type node struct {
 	p *node
 }
 
-// New returns an initialized deque.
-func New() *Deque {
-	return new(Deque)
-}
-
-// Init initializes or clears deque d.
-func (d *Deque) Init() *Deque {
-	*d = Deque{}
-	return d
-}
-
 // Len returns the number of elements of deque d.
 // The complexity is O(1).
 func (d *Deque) Len() int { return d.len }

--- a/doc_test.go
+++ b/doc_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Example_fIFOQueue() {
-	d := deque.New()
+	d := new(deque.Deque)
 
 	for i := 0; i < 5; i++ {
 		d.PushBack(i)
@@ -20,7 +20,7 @@ func Example_fIFOQueue() {
 }
 
 func Example_stack() {
-	d := deque.New()
+	d := new(deque.Deque)
 
 	for i := 0; i < 5; i++ {
 		d.PushBack(i)

--- a/integration_test.go
+++ b/integration_test.go
@@ -362,7 +362,7 @@ func pushPopFrontBackShouldRetrieveAllElementsInOrder(t *testing.T, popFunc, fro
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			d := deque.New()
+			d := new(deque.Deque)
 			lastPut := 0
 			lastGet := 0
 			var ok bool

--- a/unit_test.go
+++ b/unit_test.go
@@ -33,7 +33,7 @@ const (
 )
 
 func TestInvariants(t *testing.T) {
-	d := New()
+	d := new(Deque)
 	assertInvariants(t, d, nil)
 	for i := 0; i < maxInternalSliceSize*10; i++ {
 		d.PushBack(i)

--- a/unit_test.go
+++ b/unit_test.go
@@ -30,7 +30,7 @@ const (
 )
 
 func TestNewShouldReturnInitiazedInstanceOfDeque(t *testing.T) {
-	d := New()
+	d := new(Deque)
 
 	if d == nil {
 		t.Error("Expected: new instance of queue; Got: nil")
@@ -62,7 +62,7 @@ func TestNewShouldReturnInitiazedInstanceOfDeque(t *testing.T) {
 }
 
 func TestPushFrontPopBackShouldHaveAllInternalLinksInARing(t *testing.T) {
-	d := New()
+	d := new(Deque)
 	pushValue, extraAddedItems, spareLinks := 0, 0, 0
 
 	// Push maxFirstSliceSize items to fill the first array
@@ -230,7 +230,7 @@ func TestPushFrontPopBackShouldHaveAllInternalLinksInARing(t *testing.T) {
 }
 
 func TestPushFrontPopFrontShouldHaveAllInternalLinksInARing(t *testing.T) {
-	d := New()
+	d := new(Deque)
 	pushValue, spareLinks := 0, 0
 
 	// Push maxFirstSliceSize + maxInternalSliceSize + 1 items to fill the first, second
@@ -350,7 +350,7 @@ func TestPushFrontPopFrontShouldHaveAllInternalLinksInARing(t *testing.T) {
 }
 
 func TestPushBackPopBackShouldHaveAllInternalLinksInARing(t *testing.T) {
-	d := New()
+	d := new(Deque)
 	pushValue, extraAddedItems, spareLinks := 0, 0, 0
 
 	// Push maxFirstSliceSize items to fill the first array
@@ -505,7 +505,7 @@ func TestPushBackPopBackShouldHaveAllInternalLinksInARing(t *testing.T) {
 }
 
 func TestPushBackPopFrontShouldHaveAllInternalLinksInARing(t *testing.T) {
-	d := New()
+	d := new(Deque)
 	pushValue, spareLinks := 0, 0
 
 	// Push maxFirstSliceSize + maxInternalSliceSize + 1 items to fill the first, second
@@ -639,7 +639,7 @@ func TestPushBackPopFrontShouldHaveAllInternalLinksInARing(t *testing.T) {
 }
 
 func TestPushFrontShouldReuseSpareLinks(t *testing.T) {
-	d := New()
+	d := new(Deque)
 	count := maxInternalSliceSize * 3
 	// Fills the deque
 	for i := 0; i < count; i++ {
@@ -665,7 +665,7 @@ func TestPushFrontShouldReuseSpareLinks(t *testing.T) {
 }
 
 func TestPushBackShouldReuseSpareLinks(t *testing.T) {
-	d := New()
+	d := new(Deque)
 	count := maxInternalSliceSize * 3
 	// Fills the deque
 	for i := 0; i < count; i++ {
@@ -691,7 +691,7 @@ func TestPushBackShouldReuseSpareLinks(t *testing.T) {
 }
 
 func TestPopFrontWithRefillShouldKeepMaxSpareLinks(t *testing.T) {
-	d := New()
+	d := new(Deque)
 	count := maxInternalSliceSize * (maxSpareLinks + 2)
 	for i := 0; i < refillCount; i++ {
 		for j := 0; j < count; j++ {
@@ -724,7 +724,7 @@ func TestPopFrontWithRefillShouldKeepMaxSpareLinks(t *testing.T) {
 }
 
 func TestPopBackWithRefillShouldKeepMaxSpareLinks(t *testing.T) {
-	d := New()
+	d := new(Deque)
 	count := maxInternalSliceSize * (maxSpareLinks + 2)
 	for i := 0; i < refillCount; i++ {
 		for j := 0; j < count; j++ {


### PR DESCRIPTION
As the zero value is OK to use, the New method is unnecessary.

Likewise, the Init method isn't necessary (`*d = deque.Deque{}` suffices).

Note that the existing Init method didn't actually clear all the fields (it didn't initialize lastTailPosition).