### PR TITLE
simplify push logic

### DIFF
--- a/deque.go
+++ b/deque.go
@@ -78,9 +78,6 @@ type Deque struct {
 	// Len holds the current deque values length.
 	len int
 
-	// lastTailPosition holds the index pointing to the last tail position.
-	lastTailPosition int
-
 	// spareLinks holds the number of already used, but now empty, ready-to-be-reused, slices.
 	spareLinks int
 }
@@ -140,27 +137,22 @@ func (d *Deque) Back() (interface{}, bool) {
 func (d *Deque) PushFront(v interface{}) {
 	switch {
 	case d.head == nil:
+		// No nodes present yet.
 		h := &node{v: make([]interface{}, firstSliceSize)}
 		h.n = h
 		h.p = h
 		d.head = h
 		d.tail = h
-		d.lastTailPosition = maxFirstSliceSize - 1
 	case d.hp > 0:
+		// There's already room in the head slice.
 		d.hp--
 	case d.head.p != d.tail:
+		// There's at least one spare link between head and tail nodes.
 		d.head = d.head.p
 		d.hp = len(d.head.v) - 1
 		d.spareLinks--
-	case d.head != d.tail:
-		n := &node{v: make([]interface{}, maxInternalSliceSize)}
-		n.n = d.head
-		n.p = d.tail
-		d.head.p = n
-		d.tail.n = n
-		d.head = n
-		d.hp = maxInternalSliceSize - 1
-	case d.tp >= len(d.head.v)-1 && len(d.head.v) < maxFirstSliceSize:
+	case len(d.head.v) < maxFirstSliceSize:
+		// The first slice hasn't grown big enough yet.
 		l := len(d.head.v)
 		nl := l * sliceGrowthFactor
 		n := make([]interface{}, nl)
@@ -170,6 +162,7 @@ func (d *Deque) PushFront(v interface{}) {
 		d.head.v = n
 		d.hp--
 	default:
+		// No available nodes, so make one.
 		n := &node{v: make([]interface{}, maxInternalSliceSize)}
 		n.n = d.head
 		n.p = d.tail
@@ -177,8 +170,6 @@ func (d *Deque) PushFront(v interface{}) {
 		d.tail.n = n
 		d.head = n
 		d.hp = maxInternalSliceSize - 1
-		d.tp = len(d.tail.v) - 1
-		d.lastTailPosition = maxInternalSliceSize - 1
 	}
 	d.len++
 	d.head.v[d.hp] = v
@@ -189,34 +180,36 @@ func (d *Deque) PushFront(v interface{}) {
 func (d *Deque) PushBack(v interface{}) {
 	switch {
 	case d.head == nil:
+		// No nodes present yet.
 		h := &node{v: make([]interface{}, firstSliceSize)}
 		h.n = h
 		h.p = h
 		d.head = h
 		d.tail = h
-		d.lastTailPosition = maxFirstSliceSize - 1
-	case d.tp >= d.lastTailPosition:
-		var n *node
-		if d.tail.n != d.head {
-			d.spareLinks--
-			n = d.tail.n
-		} else {
-			n = &node{v: make([]interface{}, maxInternalSliceSize)}
-			n.n = d.head
-			n.p = d.tail
-			d.tail.n = n
-			d.head.p = n
-			d.lastTailPosition = maxInternalSliceSize - 1
-		}
+	case d.tp < len(d.tail.v)-1:
+		// There's room in the tail slice.
+		d.tp++
+	case d.tp < maxFirstSliceSize-1:
+		// We're on the first slice and it hasn't grown large enough yet.
+		nv := make([]interface{}, len(d.tail.v)*sliceGrowthFactor)
+		copy(nv, d.tail.v)
+		d.tail.v = nv
+		d.tp++
+	case d.tail.n != d.head:
+		// There's at least one spare link between head and tail nodes.
+		d.spareLinks--
+		n := d.tail.n
 		d.tp = 0
 		d.tail = n
 	default:
-		d.tp++
-		if d.tp >= len(d.tail.v) {
-			n := make([]interface{}, len(d.tail.v)*sliceGrowthFactor)
-			copy(n, d.tail.v)
-			d.tail.v = n
-		}
+		// No available nodes, so make one.
+		n := &node{v: make([]interface{}, maxInternalSliceSize)}
+		n.n = d.head
+		n.p = d.tail
+		d.tail.n = n
+		d.head.p = n
+		d.tp = 0
+		d.tail = n
 	}
 	d.len++
 	d.tail.v[d.tp] = v

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.11
 
 require (
 	github.com/christianrpetrin/queue-tests v0.0.0-20181113195552-8536b5b8f660
+	github.com/davecgh/go-spew v1.1.1
 	github.com/gammazero/deque v0.0.0-20180920172122-f6adf94963e4
+	github.com/kr/pretty v0.1.0
 	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d
 	gopkg.in/karalabe/cookiejar.v2 v2.0.0-20150724131613-8dcd6a7f4951
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,14 @@
 github.com/christianrpetrin/queue-tests v0.0.0-20181113195552-8536b5b8f660 h1:T4BnFIqh6Seu950iWM5xBBO243119XTcg61Fvs9vHUo=
 github.com/christianrpetrin/queue-tests v0.0.0-20181113195552-8536b5b8f660/go.mod h1:ugRPbaHYSO8Ewen14D8j/131oaTGup0SlHocDQ3oIOM=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gammazero/deque v0.0.0-20180920172122-f6adf94963e4 h1:R+19WKQClnfMXS60cP5BmMe1wjZ4u0evY2p2Ar0ZTXo=
 github.com/gammazero/deque v0.0.0-20180920172122-f6adf94963e4/go.mod h1:GeIq9qoE43YdGnDXURnmKTnGg15pQz4mYkXSTChbneI=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d h1:U+PMnTlV2tu7RuMK5etusZG3Cf+rpow5hqQByeCzJ2g=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d/go.mod h1:lXfE4PvvTW5xOjO6Mba8zDPyw8M93B6AQ7frTGnMlA8=
 gopkg.in/karalabe/cookiejar.v2 v2.0.0-20150724131613-8dcd6a7f4951 h1:DMTcQRFbEH62YPRWwOI647s2e5mHda3oBPMHfrLs2bw=

--- a/unit_test.go
+++ b/unit_test.go
@@ -21,7 +21,10 @@
 package deque
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 const (
@@ -31,33 +34,24 @@ const (
 
 func TestNewShouldReturnInitiazedInstanceOfDeque(t *testing.T) {
 	d := New()
+	assertInvariants(t, d, nil)
+}
 
-	if d == nil {
-		t.Error("Expected: new instance of queue; Got: nil")
+func TestInvariants(t *testing.T) {
+	d := New()
+	assertInvariants(t, d, nil)
+	for i := 0; i < maxInternalSliceSize*10; i++ {
+		d.PushBack(i)
+		assertInvariants(t, d, func(i int) interface{} {
+			return i
+		})
 	}
-	if d.Len() != 0 {
-		t.Errorf("Expected: %d; Got: %d", 0, d.Len())
-	}
-	if _, ok := d.Back(); ok {
-		t.Error("Expected: false; Got: true")
-	}
-	if _, ok := d.Front(); ok {
-		t.Error("Expected: false; Got: true")
-	}
-	if d.head != nil {
-		t.Error("Expected: d.head == nil; Got: d.head != nil")
-	}
-	if d.tail != nil {
-		t.Error("Expected: d.tail == nil; Got: d.tail != nil")
-	}
-	if d.tp != 0 {
-		t.Errorf("Expected: %d; Got: %d", 0, d.tp)
-	}
-	if d.hp != 0 {
-		t.Errorf("Expected: %d; Got: %d", 0, d.hp)
-	}
-	if d.spareLinks != 0 {
-		t.Errorf("Expected: %d; Got: %d", 0, d.spareLinks)
+
+	for i := 0; i < maxInternalSliceSize*10; i++ {
+		d.PopBack()
+		assertInvariants(t, d, func(i int) interface{} {
+			return i
+		})
 	}
 }
 
@@ -760,28 +754,180 @@ func TestPopBackWithRefillShouldKeepMaxSpareLinks(t *testing.T) {
 
 // Checks the internal slices and its links.
 func checkLinks(t *testing.T, d *Deque, length, headSliceSize, tailSliceSize, spareLinks int, headNext, headPrevious, tailNext, tailPrevious *node) {
+	t.Helper()
 	if d.Len() != length {
-		t.Errorf("Expected: %d; Got: %d", length, d.Len())
+		t.Errorf("unexpected length; Expected: %d; Got: %d", length, d.Len())
 	}
 	if len(d.head.v) != headSliceSize {
-		t.Errorf("Expected: %d; Got: %d", headSliceSize, len(d.head.v))
+		t.Errorf("unexpected head size; Expected: %d; Got: %d", headSliceSize, len(d.head.v))
 	}
 	if d.head.n != headNext {
-		t.Error("Expected: d.head.n == headNext; Got: d.head.n != headNext")
+		t.Error("unexpected head node; Expected: d.head.n == headNext; Got: d.head.n != headNext")
 	}
 	if d.head.p != headPrevious {
-		t.Error("Expected: d.head.p == headPrevious; Got: d.head.p != headPrevious")
+		t.Error("unexpected head; Expected: d.head.p == headPrevious; Got: d.head.p != headPrevious")
 	}
 	if d.tail.n != tailNext {
-		t.Error("Expected: d.tail.n == tailNext; Got: d.tail.n != tailNext")
+		t.Error("unexpected tailNext; Expected: d.tail.n == tailNext; Got: d.tail.n != tailNext")
 	}
 	if d.tail.p != tailPrevious {
-		t.Error("Expected: d.tail.p == tailPrevious; Got: d.tail.p != tailPrevious")
+		t.Error("unexpected tailPrevious; Expected: d.tail.p == tailPrevious; Got: d.tail.p != tailPrevious")
 	}
 	if len(d.tail.v) != tailSliceSize {
-		t.Errorf("Expected: %d; Got: %d", tailSliceSize, len(d.tail.v))
+		t.Errorf("unexpected tail size; Expected: %d; Got: %d", tailSliceSize, len(d.tail.v))
 	}
 	if d.spareLinks != spareLinks {
-		t.Errorf("Expected: %d; Got: %d", spareLinks, d.spareLinks)
+		t.Errorf("unexpected spare link count; Expected: %d; Got: %d", spareLinks, d.spareLinks)
+	}
+	if t.Failed() {
+		t.FailNow()
+	}
+}
+
+// assertInvariants checks all the invariant conditions in d that we can think of.
+// If val is non-nil it is used to find the expected value for an item at index
+// i measured from the head of the queue.
+func assertInvariants(t *testing.T, d *Deque, val func(i int) interface{}) {
+	t.Helper()
+	fail := func(what string, got, want interface{}) {
+		t.Log(spew.Sdump(d))
+		t.Errorf("invariant fail: %s; got %v want %v", what, got, want)
+	}
+	if d == nil {
+		fail("non-nil Deque", d, "non-nil")
+	}
+	if d.head == nil {
+		// Zero value.
+		if d.tail != nil {
+			fail("nil tail when zero", d.tail, nil)
+		}
+		if d.len != 0 {
+			fail("zero length when zero", d.len, 0)
+		}
+		if d.hp != 0 {
+			fail("zero hp when zero", d.hp, 0)
+		}
+		if d.tp != 0 {
+			fail("zero tp when zero", d.tp, 0)
+		}
+		if d.spareLinks != 0 {
+			fail("no spare links when zero", d.spareLinks, 0)
+		}
+		return
+	}
+	if d.head == d.tail {
+		if d.len == 0 {
+			if d.tp != -1 {
+				fail("tail index == -1 when empty", d.tp, -1)
+			}
+			if d.hp != 0 {
+				fail("head index == 0 when empty", d.hp, 0)
+			}
+		} else {
+			if d.hp > d.tp {
+				fail("head index exceeds tail index", d.hp, d.tp)
+			}
+		}
+	}
+	spareLinkCount := 0
+	inQueue := true
+	elemCount := 0
+	smallNodeCount := 0
+	index := 0
+	walkLinks(t, d, func(n *node) {
+		if len(n.v) < maxInternalSliceSize {
+			smallNodeCount++
+			if len(n.v) > maxFirstSliceSize {
+				fail("first node within bounds", len(n.v), maxFirstSliceSize)
+			}
+		}
+		if len(n.v) > maxInternalSliceSize {
+			fail("slice too big", len(n.v), maxInternalSliceSize)
+		}
+		for i, v := range n.v {
+			failElem := func(what string, got, want interface{}) {
+				fail(fmt.Sprintf("at elem %d, node %p, %s", i, n, what), got, want)
+				t.FailNow()
+			}
+			if !inQueue {
+				if v != nil {
+					failElem("all values outside queue nil", v, nil)
+				}
+				continue
+			}
+			elemInQueue := inQueue
+			switch {
+			case n == d.head && n == d.tail:
+				elemInQueue = i >= d.hp && i <= d.tp
+			case n == d.head:
+				elemInQueue = i >= d.hp
+			case n == d.tail:
+				elemInQueue = i <= d.tp
+			}
+			if elemInQueue {
+				if v == nil {
+					failElem("all values inside queue non-nil", v, "non-nil")
+				}
+			} else {
+				if v != nil {
+					failElem("all values outside queue nil", v, nil)
+				}
+			}
+			if v != nil {
+				if val != nil {
+					want := val(index)
+					if want != v {
+						failElem(fmt.Sprintf("element %d has expected value", index), v, want)
+					}
+				}
+				elemCount++
+				index++
+			}
+		}
+		if !inQueue {
+			spareLinkCount++
+		}
+		if n == d.tail {
+			inQueue = false
+		}
+	})
+	if inQueue {
+		// We never encountered the tail pointer.
+		t.Errorf("tail does not point to element in list")
+	}
+	if spareLinkCount > maxSpareLinks {
+		fail("spare link count <= maxSpareLinks", spareLinkCount, maxSpareLinks)
+	}
+	if elemCount != d.len {
+		fail("element count == d.len", elemCount, d.len)
+	}
+	if smallNodeCount > 1 {
+		fail("only one first node", smallNodeCount, 1)
+	}
+	if t.Failed() {
+		t.FailNow()
+	}
+}
+
+// walkLinks calls f for each node in the linked list.
+// It also checks link invariants:
+func walkLinks(t *testing.T, d *Deque, f func(n *node)) {
+	t.Helper()
+	fail := func(what string, got, want interface{}) {
+		t.Errorf("link invariant %s fail; got %v want %v", what, got, want)
+	}
+	n := d.head
+	for {
+		if n.n.p != n {
+			fail("node.n.p == node", n.n.p, n)
+		}
+		if n.p.n != n {
+			fail("node.p.n == node", n.p.n, n)
+		}
+		f(n)
+		n = n.n
+		if n == d.head {
+			break
+		}
 	}
 }


### PR DESCRIPTION
The lastTailPosition field is unnecessary, as it's only used for the first
block, and we can always tell if we're on the first block by checking the
block length.

Initially, this code changed some invariants which caused the unit tests
to fail. Although this was an issue with the code, the reason for the unit
test failure was obscure, and changing the invariants would require
changing a lot of fairly obscure unit tests. As a possible alternative approach,
I've added `assertInvariants`, a function which checks all known
invariants and could be called at any point. This also provides some
reasonable documentation of what the invariants actually are (it
would be nice if they were also documented better in the code).

Then the code could be refactored more freely while only changing
a single invariant checker function.

As an aside, it's not clear why we have different max size behaviour for
the first slice versus the rest. Why not let the first slice expand to 256
instead of 16? That would simplify the code a little more.

Performance seems generally better or around the same:

	benchmark                                     old ns/op     new ns/op     delta
	BenchmarkFillDequeQueue/0-4                   42.6          41.0          -3.76%
	BenchmarkFillDequeQueue/1-4                   178           151           -15.17%
	BenchmarkFillDequeQueue/10-4                  712           687           -3.51%
	BenchmarkFillDequeQueue/100-4                 5367          5351          -0.30%
	BenchmarkFillDequeQueue/1000-4                44308         44448         +0.32%
	BenchmarkFillDequeQueue/10000-4               436426        468247        +7.29%
	BenchmarkFillDequeQueue/100000-4              4701266       5020198       +6.78%
	BenchmarkFillDequeQueue/1000000-4             52650621      57124863      +8.50%
	BenchmarkFillDequeStack/0-4                   43.0          40.5          -5.81%
	BenchmarkFillDequeStack/1-4                   163           160           -1.84%
	BenchmarkFillDequeStack/10-4                  704           726           +3.12%
	BenchmarkFillDequeStack/100-4                 6206          5500          -11.38%
	BenchmarkFillDequeStack/1000-4                82310         43529         -47.12%
	BenchmarkFillDequeStack/10000-4               558683        430710        -22.91%
	BenchmarkFillDequeStack/100000-4              5157938       4695966       -8.96%
	BenchmarkFillDequeStack/1000000-4             57210349      55608442      -2.80%
	BenchmarkMicroserviceDequeQueue/1-4           617           563           -8.75%
	BenchmarkMicroserviceDequeQueue/10-4          4345          4070          -6.33%
	BenchmarkMicroserviceDequeQueue/100-4         30772         28047         -8.86%
	BenchmarkMicroserviceDequeQueue/1000-4        263054        272522        +3.60%
	BenchmarkMicroserviceDequeQueue/10000-4       2794353       2834015       +1.42%
	BenchmarkMicroserviceDequeQueue/100000-4      30656758      30792600      +0.44%
	BenchmarkMicroserviceDequeQueue/1000000-4     310948195     322120527     +3.59%
	BenchmarkMicroserviceDequeStack/1-4           528           457           -13.45%
	BenchmarkMicroserviceDequeStack/10-4          3405          3060          -10.13%
	BenchmarkMicroserviceDequeStack/100-4         30136         27090         -10.11%
	BenchmarkMicroserviceDequeStack/1000-4        349095        260084        -25.50%
	BenchmarkMicroserviceDequeStack/10000-4       4842273       2779491       -42.60%
	BenchmarkMicroserviceDequeStack/100000-4      30376486      30133643      -0.80%
	BenchmarkMicroserviceDequeStack/1000000-4     403197125     314148386     -22.09%
	BenchmarkRefillFullDequeQueue/1-4             5306          4137          -22.03%
	BenchmarkRefillFullDequeQueue/10-4            40988         41801         +1.98%
	BenchmarkRefillFullDequeQueue/100-4           556997        422356        -24.17%
	BenchmarkRefillFullDequeQueue/1000-4          5747318       4039626       -29.71%
	BenchmarkRefillFullDequeQueue/10000-4         50574502      49336337      -2.45%
	BenchmarkRefillFullDequeQueue/100000-4        480063868     496396217     +3.40%
	BenchmarkRefillFullDequeStack/1-4             4972          4494          -9.61%
	BenchmarkRefillFullDequeStack/10-4            40274         43639         +8.36%
	BenchmarkRefillFullDequeStack/100-4           394611        396665        +0.52%
	BenchmarkRefillFullDequeStack/1000-4          3978534       4017593       +0.98%
	BenchmarkRefillFullDequeStack/10000-4         45048073      44497156      -1.22%
	BenchmarkRefillFullDequeStack/100000-4        463631405     473849367     +2.20%
	BenchmarkRefillDequeQueue/1-4                 4259          4487          +5.35%
	BenchmarkRefillDequeQueue/10-4                40429         46295         +14.51%
	BenchmarkRefillDequeQueue/100-4               395224        430059        +8.81%
	BenchmarkRefillDequeQueue/1000-4              3951623       4097020       +3.68%
	BenchmarkRefillDequeQueue/10000-4             43354326      47419649      +9.38%
	BenchmarkRefillDequeQueue/100000-4            474838615     507786535     +6.94%
	BenchmarkRefillDequeStack/1-4                 4187          4195          +0.19%
	BenchmarkRefillDequeStack/10-4                40136         43958         +9.52%
	BenchmarkRefillDequeStack/100-4               388252        414602        +6.79%
	BenchmarkRefillDequeStack/1000-4              3813335       4212829       +10.48%
	BenchmarkRefillDequeStack/10000-4             42989920      47718678      +11.00%
	BenchmarkRefillDequeStack/100000-4            470917806     507785491     +7.83%
	BenchmarkSlowDecreaseDequeQueue/1-4           40.4          42.4          +4.95%
	BenchmarkSlowDecreaseDequeQueue/10-4          407           454           +11.55%
	BenchmarkSlowDecreaseDequeQueue/100-4         3951          4747          +20.15%
	BenchmarkSlowDecreaseDequeQueue/1000-4        40705         41896         +2.93%
	BenchmarkSlowDecreaseDequeQueue/10000-4       403659        430482        +6.64%
	BenchmarkSlowDecreaseDequeQueue/100000-4      3957679       4371165       +10.45%
	BenchmarkSlowDecreaseDequeQueue/1000000-4     38944592      42589633      +9.36%
	BenchmarkSlowDecreaseDequeStack/1-4           47.9          42.6          -11.06%
	BenchmarkSlowDecreaseDequeStack/10-4          512           431           -15.82%
	BenchmarkSlowDecreaseDequeStack/100-4         5033          4232          -15.91%
	BenchmarkSlowDecreaseDequeStack/1000-4        38407         41127         +7.08%
	BenchmarkSlowDecreaseDequeStack/10000-4       394338        424500        +7.65%
	BenchmarkSlowDecreaseDequeStack/100000-4      4137764       4159700       +0.53%
	BenchmarkSlowDecreaseDequeStack/1000000-4     39012681      41832207      +7.23%
	BenchmarkSlowIncreaseDequeQueue/1-4           340           283           -16.76%
	BenchmarkSlowIncreaseDequeQueue/10-4          2280          2309          +1.27%
	BenchmarkSlowIncreaseDequeQueue/100-4         9023          9635          +6.78%
	BenchmarkSlowIncreaseDequeQueue/1000-4        84790         87842         +3.60%
	BenchmarkSlowIncreaseDequeQueue/10000-4       1054093       888949        -15.67%
	BenchmarkSlowIncreaseDequeQueue/100000-4      11396544      10057962      -11.75%
	BenchmarkSlowIncreaseDequeQueue/1000000-4     115985396     106593814     -8.10%
	BenchmarkSlowIncreaseDequeStack/1-4           336           286           -14.88%
	BenchmarkSlowIncreaseDequeStack/10-4          1105          1138          +2.99%
	BenchmarkSlowIncreaseDequeStack/100-4         11422         9511          -16.73%
	BenchmarkSlowIncreaseDequeStack/1000-4        90291         81974         -9.21%
	BenchmarkSlowIncreaseDequeStack/10000-4       973651        839611        -13.77%
	BenchmarkSlowIncreaseDequeStack/100000-4      11435655      9859417       -13.78%
	BenchmarkSlowIncreaseDequeStack/1000000-4     101713693     108145656     +6.32%
	BenchmarkStableDequeQueue/1-4                 43.5          43.0          -1.15%
	BenchmarkStableDequeQueue/10-4                417           420           +0.72%
	BenchmarkStableDequeQueue/100-4               3981          4212          +5.80%
	BenchmarkStableDequeQueue/1000-4              39733         40513         +1.96%
	BenchmarkStableDequeQueue/10000-4             408448        404425        -0.98%
	BenchmarkStableDequeQueue/100000-4            3959589       4175790       +5.46%
	BenchmarkStableDequeQueue/1000000-4           39721862      41249243      +3.85%
	BenchmarkStableDequeStack/1-4                 44.2          44.1          -0.23%
	BenchmarkStableDequeStack/10-4                451           434           -3.77%
	BenchmarkStableDequeStack/100-4               4413          4417          +0.09%
	BenchmarkStableDequeStack/1000-4              41397         42712         +3.18%
	BenchmarkStableDequeStack/10000-4             420809        436227        +3.66%
	BenchmarkStableDequeStack/100000-4            4339661       4312148       -0.63%
	BenchmarkStableDequeStack/1000000-4           42356775      43244007      +2.09%