### PR TITLE
Simplify tail index invariant

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,7 @@ go 1.11
 
 require (
 	github.com/christianrpetrin/queue-tests v0.0.0-20181113195552-8536b5b8f660
-	github.com/davecgh/go-spew v1.1.1
 	github.com/gammazero/deque v0.0.0-20180920172122-f6adf94963e4
-	github.com/kr/pretty v0.1.0
 	github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d
 	gopkg.in/karalabe/cookiejar.v2 v2.0.0-20150724131613-8dcd6a7f4951
 )

--- a/go.sum
+++ b/go.sum
@@ -1,14 +1,7 @@
 github.com/christianrpetrin/queue-tests v0.0.0-20181113195552-8536b5b8f660 h1:T4BnFIqh6Seu950iWM5xBBO243119XTcg61Fvs9vHUo=
 github.com/christianrpetrin/queue-tests v0.0.0-20181113195552-8536b5b8f660/go.mod h1:ugRPbaHYSO8Ewen14D8j/131oaTGup0SlHocDQ3oIOM=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gammazero/deque v0.0.0-20180920172122-f6adf94963e4 h1:R+19WKQClnfMXS60cP5BmMe1wjZ4u0evY2p2Ar0ZTXo=
 github.com/gammazero/deque v0.0.0-20180920172122-f6adf94963e4/go.mod h1:GeIq9qoE43YdGnDXURnmKTnGg15pQz4mYkXSTChbneI=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
-github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
-github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d h1:U+PMnTlV2tu7RuMK5etusZG3Cf+rpow5hqQByeCzJ2g=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d/go.mod h1:lXfE4PvvTW5xOjO6Mba8zDPyw8M93B6AQ7frTGnMlA8=
 gopkg.in/karalabe/cookiejar.v2 v2.0.0-20150724131613-8dcd6a7f4951 h1:DMTcQRFbEH62YPRWwOI647s2e5mHda3oBPMHfrLs2bw=


### PR DESCRIPTION
Currently the tp field is the index of the last element of the queue. This makes things awkward when there are no elements in the queue, as tp can be negative.

This PR changes the invariant to use a half-open interval,
so when d.head == d.tail, d.tp-d.hp == d.len.

This simplifies some of the required checks and speeds things up a bit
more in most cases. It also means that when the queue becomes empty,
the head index still points to the same place in the slice rather than
being reset to zero, which could have potentially beneficial cache
behaviour. There were some occasions previously when the invariants were
not being maintained correctly.

Also change PopFront and PopBack so they use the switch style,
to mirror PushFront and PushBack and make the symmetry more
evident.

Benchmark note: I've noticed that getTestValue allocates a new
value, which means that a lot of the benchmarks are essentially
just benchmarking the garbage collector. I'd suggest changing
getTestValue so that it doesn't allocate (it could just return nil)
so we're measuring more of the Deque operations themselves.
Also, by not using the Direct benchmarks, we'll be seeing a significant
amount of overhead from the indirect function calls.
How about moving all the comparison benchmarks into another package
(or even another repository, losing the additional dependencies)
and have the benchmarks in the deque package call Deque directly?

	benchmark                                     old ns/op     new ns/op     delta
	BenchmarkFillDequeQueue/0-4                   41.0          40.6          -0.98%
	BenchmarkFillDequeQueue/1-4                   151           153           +1.32%
	BenchmarkFillDequeQueue/10-4                  687           701           +2.04%
	BenchmarkFillDequeQueue/100-4                 5351          5741          +7.29%
	BenchmarkFillDequeQueue/1000-4                44448         43671         -1.75%
	BenchmarkFillDequeQueue/10000-4               468247        427159        -8.77%
	BenchmarkFillDequeQueue/100000-4              5020198       4643671       -7.50%
	BenchmarkFillDequeQueue/1000000-4             57124863      51463163      -9.91%
	BenchmarkFillDequeStack/0-4                   40.5          41.6          +2.72%
	BenchmarkFillDequeStack/1-4                   160           152           -5.00%
	BenchmarkFillDequeStack/10-4                  726           703           -3.17%
	BenchmarkFillDequeStack/100-4                 5500          5137          -6.60%
	BenchmarkFillDequeStack/1000-4                43529         41215         -5.32%
	BenchmarkFillDequeStack/10000-4               430710        423533        -1.67%
	BenchmarkFillDequeStack/100000-4              4695966       4540831       -3.30%
	BenchmarkFillDequeStack/1000000-4             55608442      52804653      -5.04%
	BenchmarkMicroserviceDequeQueue/1-4           563           564           +0.18%
	BenchmarkMicroserviceDequeQueue/10-4          4070          4043          -0.66%
	BenchmarkMicroserviceDequeQueue/100-4         28047         27755         -1.04%
	BenchmarkMicroserviceDequeQueue/1000-4        272522        254461        -6.63%
	BenchmarkMicroserviceDequeQueue/10000-4       2834015       2706497       -4.50%
	BenchmarkMicroserviceDequeQueue/100000-4      30792600      29030662      -5.72%
	BenchmarkMicroserviceDequeQueue/1000000-4     322120527     314382223     -2.40%
	BenchmarkMicroserviceDequeStack/1-4           457           458           +0.22%
	BenchmarkMicroserviceDequeStack/10-4          3060          2803          -8.40%
	BenchmarkMicroserviceDequeStack/100-4         27090         26568         -1.93%
	BenchmarkMicroserviceDequeStack/1000-4        260084        246662        -5.16%
	BenchmarkMicroserviceDequeStack/10000-4       2779491       2626989       -5.49%
	BenchmarkMicroserviceDequeStack/100000-4      30133643      29853479      -0.93%
	BenchmarkMicroserviceDequeStack/1000000-4     314148386     299739023     -4.59%
	BenchmarkRefillFullDequeQueue/1-4             4137          4227          +2.18%
	BenchmarkRefillFullDequeQueue/10-4            41801         42307         +1.21%
	BenchmarkRefillFullDequeQueue/100-4           422356        414239        -1.92%
	BenchmarkRefillFullDequeQueue/1000-4          4039626       4188760       +3.69%
	BenchmarkRefillFullDequeQueue/10000-4         49336337      48271926      -2.16%
	BenchmarkRefillFullDequeQueue/100000-4        496396217     472090122     -4.90%
	BenchmarkRefillFullDequeStack/1-4             4494          4445          -1.09%
	BenchmarkRefillFullDequeStack/10-4            43639         41544         -4.80%
	BenchmarkRefillFullDequeStack/100-4           396665        405062        +2.12%
	BenchmarkRefillFullDequeStack/1000-4          4017593       4367708       +8.71%
	BenchmarkRefillFullDequeStack/10000-4         44497156      45496340      +2.25%
	BenchmarkRefillFullDequeStack/100000-4        473849367     474042282     +0.04%
	BenchmarkRefillDequeQueue/1-4                 4487          4311          -3.92%
	BenchmarkRefillDequeQueue/10-4                46295         41758         -9.80%
	BenchmarkRefillDequeQueue/100-4               430059        404069        -6.04%
	BenchmarkRefillDequeQueue/1000-4              4097020       4111534       +0.35%
	BenchmarkRefillDequeQueue/10000-4             47419649      44989606      -5.12%
	BenchmarkRefillDequeQueue/100000-4            507786535     489830485     -3.54%
	BenchmarkRefillDequeStack/1-4                 4195          4316          +2.88%
	BenchmarkRefillDequeStack/10-4                43958         42946         -2.30%
	BenchmarkRefillDequeStack/100-4               414602        455875        +9.95%
	BenchmarkRefillDequeStack/1000-4              4212829       4028948       -4.36%
	BenchmarkRefillDequeStack/10000-4             47718678      44628201      -6.48%
	BenchmarkRefillDequeStack/100000-4            507785491     498792341     -1.77%
	BenchmarkSlowDecreaseDequeQueue/1-4           42.4          39.7          -6.37%
	BenchmarkSlowDecreaseDequeQueue/10-4          454           431           -5.07%
	BenchmarkSlowDecreaseDequeQueue/100-4         4747          4117          -13.27%
	BenchmarkSlowDecreaseDequeQueue/1000-4        41896         40593         -3.11%
	BenchmarkSlowDecreaseDequeQueue/10000-4       430482        409023        -4.98%
	BenchmarkSlowDecreaseDequeQueue/100000-4      4371165       4000746       -8.47%
	BenchmarkSlowDecreaseDequeQueue/1000000-4     42589633      40540467      -4.81%
	BenchmarkSlowDecreaseDequeStack/1-4           42.6          43.7          +2.58%
	BenchmarkSlowDecreaseDequeStack/10-4          431           406           -5.80%
	BenchmarkSlowDecreaseDequeStack/100-4         4232          4031          -4.75%
	BenchmarkSlowDecreaseDequeStack/1000-4        41127         41480         +0.86%
	BenchmarkSlowDecreaseDequeStack/10000-4       424500        422445        -0.48%
	BenchmarkSlowDecreaseDequeStack/100000-4      4159700       3997713       -3.89%
	BenchmarkSlowDecreaseDequeStack/1000000-4     41832207      39715513      -5.06%
	BenchmarkSlowIncreaseDequeQueue/1-4           283           282           -0.35%
	BenchmarkSlowIncreaseDequeQueue/10-4          2309          2335          +1.13%
	BenchmarkSlowIncreaseDequeQueue/100-4         9635          9663          +0.29%
	BenchmarkSlowIncreaseDequeQueue/1000-4        87842         81990         -6.66%
	BenchmarkSlowIncreaseDequeQueue/10000-4       888949        850276        -4.35%
	BenchmarkSlowIncreaseDequeQueue/100000-4      10057962      9586623       -4.69%
	BenchmarkSlowIncreaseDequeQueue/1000000-4     106593814     104425128     -2.03%
	BenchmarkSlowIncreaseDequeStack/1-4           286           271           -5.24%
	BenchmarkSlowIncreaseDequeStack/10-4          1138          1170          +2.81%
	BenchmarkSlowIncreaseDequeStack/100-4         9511          9123          -4.08%
	BenchmarkSlowIncreaseDequeStack/1000-4        81974         82010         +0.04%
	BenchmarkSlowIncreaseDequeStack/10000-4       839611        810556        -3.46%
	BenchmarkSlowIncreaseDequeStack/100000-4      9859417       9784659       -0.76%
	BenchmarkSlowIncreaseDequeStack/1000000-4     108145656     102662238     -5.07%
	BenchmarkStableDequeQueue/1-4                 43.0          43.5          +1.16%
	BenchmarkStableDequeQueue/10-4                420           419           -0.24%
	BenchmarkStableDequeQueue/100-4               4212          4172          -0.95%
	BenchmarkStableDequeQueue/1000-4              40513         42537         +5.00%
	BenchmarkStableDequeQueue/10000-4             404425        421830        +4.30%
	BenchmarkStableDequeQueue/100000-4            4175790       4060512       -2.76%
	BenchmarkStableDequeQueue/1000000-4           41249243      41242874      -0.02%
	BenchmarkStableDequeStack/1-4                 44.1          45.1          +2.27%
	BenchmarkStableDequeStack/10-4                434           454           +4.61%
	BenchmarkStableDequeStack/100-4               4417          4368          -1.11%
	BenchmarkStableDequeStack/1000-4              42712         42408         -0.71%
	BenchmarkStableDequeStack/10000-4             436227        432884        -0.77%
	BenchmarkStableDequeStack/100000-4            4312148       4377938       +1.53%
	BenchmarkStableDequeStack/1000000-4           43244007      43483899      +0.55%