### PR TITLE
Updated deque to cache "len(d.head.v)-1"

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -148,6 +148,25 @@ func TestStableQueueShouldRetrieveAllElementsInOrder(t *testing.T) {
 	}
 }
 
+func TestStableQueueFullShouldRetrieveAllElementsInOrder(t *testing.T) {
+	var d deque.Deque
+	for i := 0; i < pushCount; i++ {
+		d.PushBack(i)
+	}
+
+	count := 0
+	for i := 0; i < pushCount-1; i++ {
+		d.PushBack(i)
+		if v, ok := d.PopFront(); !ok || v.(int) != count {
+			t.Errorf("Expected: %d; Got: %d", count, v)
+		}
+		count++
+	}
+	if d.Len() != pushCount {
+		t.Errorf("Expected: %d; Got: %d", pushCount, d.Len())
+	}
+}
+
 func TestFillStackShouldRetrieveAllElementsInOrder(t *testing.T) {
 	var d deque.Deque
 
@@ -257,12 +276,31 @@ func TestStableStackShouldRetrieveAllElementsInOrder(t *testing.T) {
 
 	for i := 0; i < pushCount; i++ {
 		d.PushBack(i)
-		if v, ok := d.PopFront(); !ok || v.(int) != i {
+		if v, ok := d.PopBack(); !ok || v.(int) != i {
 			t.Errorf("Expected: %d; Got: %d", i, v)
 		}
 	}
 	if d.Len() != 0 {
 		t.Errorf("Expected: %d; Got: %d", 0, d.Len())
+	}
+}
+
+func TestStableFullStackShouldRetrieveAllElementsInOrder(t *testing.T) {
+	var d deque.Deque
+	for i := 0; i < pushCount; i++ {
+		d.PushBack(i)
+	}
+
+	count := 0
+	for i := 0; i < pushCount; i++ {
+		d.PushBack(i)
+		if v, ok := d.PopFront(); !ok || v.(int) != count {
+			t.Errorf("Expected: %d; Got: %d", count, v)
+		}
+		count++
+	}
+	if d.Len() != pushCount {
+		t.Errorf("Expected: %d; Got: %d", pushCount, d.Len())
 	}
 }
 


### PR DESCRIPTION
Keeping in mind that any code will run faster if it can achieve the same goal with a reduced number of executed instructions, below changes reduces PopFront by 1 instruction in most cases.

Everywhere in the code that updates "hlp" (head last position) is done very infrequently (for instance, when the deque is first initialized or when it needs to jump off to the next or previous slice).

Performance gains is pretty considerable and can be felt across most test loads.

```
benchstat testdata/BenchmarkMicroserviceDequeQueueMaster.txt testdata/BenchmarkMicroserviceDequeQueuePR.txt
name        old time/op    new time/op    delta
/1-4           510ns ± 5%     503ns ± 1%    ~     (p=0.806 n=10+8)
/10-4         3.60µs ± 5%    3.50µs ± 4%  -3.02%  (p=0.010 n=10+9)
/100-4        24.8µs ± 7%    23.5µs ± 1%  -5.24%  (p=0.000 n=10+10)
/1000-4        237µs ± 5%     230µs ± 4%  -3.07%  (p=0.017 n=9+10)
/10000-4      2.38ms ± 5%    2.30ms ± 3%  -3.44%  (p=0.000 n=10+9)
/100000-4     25.0ms ± 1%    24.9ms ± 2%    ~     (p=0.905 n=10+9)
/1000000-4     268ms ± 4%     260ms ± 1%  -2.95%  (p=0.000 n=10+10)

name        old alloc/op   new alloc/op   delta
/1-4            544B ± 0%      560B ± 0%  +2.94%  (p=0.000 n=10+10)
/10-4         5.70kB ± 0%    5.71kB ± 0%  +0.28%  (p=0.000 n=10+10)
/100-4        15.8kB ± 0%    15.8kB ± 0%  +0.10%  (p=0.000 n=10+10)
/1000-4        133kB ± 0%     133kB ± 0%  +0.01%  (p=0.000 n=10+10)
/10000-4      1.43MB ± 0%    1.43MB ± 0%  +0.00%  (p=0.000 n=10+10)
/100000-4     14.4MB ± 0%    14.4MB ± 0%  +0.00%  (p=0.000 n=10+9)
/1000000-4     144MB ± 0%     144MB ± 0%  +0.00%  (p=0.000 n=10+10)

name        old allocs/op  new allocs/op  delta
/1-4            12.0 ± 0%      12.0 ± 0%    ~     (all equal)
/10-4           77.0 ± 0%      77.0 ± 0%    ~     (all equal)
/100-4           707 ± 0%       707 ± 0%    ~     (all equal)
/1000-4        7.01k ± 0%     7.01k ± 0%    ~     (all equal)
/10000-4       70.2k ± 0%     70.2k ± 0%    ~     (all equal)
/100000-4       702k ± 0%      702k ± 0%    ~     (all equal)
/1000000-4     7.02M ± 0%     7.02M ± 0%    ~     (all equal)

benchstat testdata/BenchmarkMicroserviceDequeStackMaster.txt testdata/BenchmarkMicroserviceDequeStackPR.txt
name        old time/op    new time/op    delta
/1-4           389ns ± 1%     399ns ± 4%  +2.62%  (p=0.000 n=10+10)
/10-4         2.51µs ± 1%    2.65µs ± 5%  +5.60%  (p=0.000 n=10+10)
/100-4        22.8µs ± 1%    22.9µs ± 1%  +0.53%  (p=0.006 n=10+9)
/1000-4        220µs ± 2%     220µs ± 1%    ~     (p=0.661 n=9+10)
/10000-4      2.28ms ± 2%    2.25ms ± 0%  -1.28%  (p=0.000 n=8+10)
/100000-4     24.6ms ± 1%    25.2ms ± 5%  +2.56%  (p=0.028 n=9+10)
/1000000-4     258ms ± 1%     271ms ±12%  +4.87%  (p=0.022 n=9+10)

name        old alloc/op   new alloc/op   delta
/1-4            288B ± 0%      304B ± 0%  +5.56%  (p=0.000 n=10+10)
/10-4         1.55kB ± 0%    1.57kB ± 0%  +1.03%  (p=0.000 n=10+10)
/100-4        15.8kB ± 0%    15.8kB ± 0%  +0.10%  (p=0.000 n=10+10)
/1000-4        129kB ± 0%     129kB ± 0%  +0.01%  (p=0.000 n=10+10)
/10000-4      1.43MB ± 0%    1.43MB ± 0%  +0.00%  (p=0.000 n=10+10)
/100000-4     14.4MB ± 0%    14.4MB ± 0%  +0.00%  (p=0.000 n=10+8)
/1000000-4     144MB ± 0%     144MB ± 0%  +0.00%  (p=0.000 n=9+9)

name        old allocs/op  new allocs/op  delta
/1-4            11.0 ± 0%      11.0 ± 0%    ~     (all equal)
/10-4           75.0 ± 0%      75.0 ± 0%    ~     (all equal)
/100-4           707 ± 0%       707 ± 0%    ~     (all equal)
/1000-4        7.01k ± 0%     7.01k ± 0%    ~     (all equal)
/10000-4       70.2k ± 0%     70.2k ± 0%    ~     (all equal)
/100000-4       702k ± 0%      702k ± 0%    ~     (all equal)
/1000000-4     7.02M ± 0%     7.02M ± 0%    ~     (all equal)
```

Stack performance is slightly worse, but the gains on the queue side more than compensate for it.
