### PR TITLE
Fixed bug related to stable PushFront/PopBack

### DIFF
--- a/deque.go
+++ b/deque.go
@@ -175,6 +175,12 @@ func (d *Deque) PushFront(v interface{}) {
 		copy(n[d.hp:], d.head.v)
 		d.head.v = n
 		d.hp--
+	case d.len == 0:
+		// The head slice is empty, so reuse it.
+		d.tail = d.head
+		d.tp = len(d.head.v)
+		d.hp = d.tp - 1
+		d.hlp = d.hp
 	default:
 		// No available nodes, so make one.
 		n := &node{v: make([]interface{}, maxInternalSliceSize)}

--- a/unit_test.go
+++ b/unit_test.go
@@ -652,6 +652,26 @@ func TestPushFrontShouldReuseSpareLinks(t *testing.T) {
 	}
 }
 
+func TestPushFrontPopBackStableShouldReuseHeadSlice(t *testing.T) {
+	d := New()
+
+	for i := 0; i < pushCount; i++ {
+		d.PushFront(i)
+		v, ok := d.PopBack()
+		if !ok || v == nil || v.(int) != i {
+			t.Errorf("Expected: %d; Got: %d", i, v)
+		}
+	}
+
+	// The head slice should've been reused, so no additional slices should've been created
+	if d.head != d.tail || d.head.n != d.tail || d.head.p != d.tail {
+		t.Error("Expected to have only one head slice")
+	}
+	if d.spareLinks != 0 {
+		t.Errorf("Expected: %d spareLinks; Got: %d", maxSpareLinks, d.spareLinks)
+	}
+}
+
 func TestPushBackShouldReuseSpareLinks(t *testing.T) {
 	d := New()
 	count := maxInternalSliceSize * 3


### PR DESCRIPTION
Fixed bug reported [here](https://github.com/ef-ds/deque/issues/20).

The bug happens only when deque is used as a First-In-First-Out queue by calling PushFront and PopBack (PushFront once, then PushBack once; repeat this 65 times). Given the [recommended approach](https://github.com/ef-ds/deque#how-to-use) to use deque as a First-In-First-Out queue is to use PushBack and PopFront, we anticipate very few users are affected by this bug.

Many thanks to @jrodatus for finding and reporting the issue!